### PR TITLE
📖🐛 Fix a typo in `index.md`

### DIFF
--- a/ecosystem.md
+++ b/ecosystem.md
@@ -106,7 +106,7 @@ Migrate from RST »
 :link: https://myst-parser.readthedocs.io/
 **Highly Configurable**
 ^^^
-Configure MyST-parser at global and individual document levelss and access extended syntax features.
+Configure MyST-parser at global and individual document levels and access extended syntax features.
 +++
 Go to Project »
 :::


### PR DESCRIPTION
Takes over from #1.

Thanks @brettcannon for catching this. :)