### PR TITLE
📁 adding `thebe` and `jupyterlab` projects

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -23,6 +23,10 @@ site:
           url: /docs/myst-transforms
         - title: MyST Spec
           url: /docs/spec
+        - title: Thebe
+          url: /docs/thebe
+        - title: MyST in Jupyter Lab
+          url: /docs/jupyterlab
     - title: Community
       url: https://github.com/orgs/executablebooks/discussions
     - title: Try MyST


### PR DESCRIPTION
This add the two latest documentation sets to the projects menu