### PR TITLE
:gear: Add `url` param to sandbox

### DIFF
--- a/theme/app/routes/sandbox.tsx
+++ b/theme/app/routes/sandbox.tsx
@@ -48,8 +48,15 @@ export const loader: LoaderFunction = async ({ request }) => {
   const url = new URL(request.url);
   const myst = url.searchParams.get('myst');
   const tab = url.searchParams.get('tab');
-
-  const data = myst ? fromBinary(atob(myst)) : undefined;
+  const srcURL = url.searchParams.get("url");
+  
+  let data;
+  if (srcURL) {
+    const response = await fetch(srcURL);
+    data = await response.text();
+  } else {
+    data = myst ? fromBinary(atob(myst)) : undefined;
+  }
   return json({ data, tab });
 };
 


### PR DESCRIPTION
This PR adds an `url` parameter to the sandbox, enabling people to preview MyST documents online.

I'd like to explicitly reference that somewhere, but I'm not sure whether we want to add description text to the sandbox page. I could modify the demo text, as an explainer?

Closes executablebooks/mystmd.org#4