### PR TITLE
👪 Pass `root.children` to tree renderer

### DIFF
--- a/theme/app/components/ArticlePage.tsx
+++ b/theme/app/components/ArticlePage.tsx
@@ -80,7 +80,7 @@ export function ArticlePage({
           )}
           <div id="skip-to-article" />
           <FrontmatterParts parts={parts} keywords={keywords} hideKeywords={hideKeywords} />
-          <MyST ast={tree} />
+          <MyST ast={tree.children} />
           <BackmatterParts parts={parts} />
           <Footnotes />
           <Bibliography />

--- a/theme/app/routes/$project.($slug).tsx
+++ b/theme/app/routes/$project.($slug).tsx
@@ -92,7 +92,7 @@ export default function Page() {
                   </div>
                 )}
                 <div id="skip-to-article" />
-                <MyST ast={article.mdast} />
+                <MyST ast={article.mdast.children} />
                 <Footnotes />
                 <Bibliography />
                 {!hide_footer_links && <FooterLinksBlock links={article.footer} />}


### PR DESCRIPTION
Fixes landing page demos!

A separate upstream fix for the root renderer is also in flight