### PR TITLE
🔗 Don't include `?url` in sandbox copy button link

### DIFF
--- a/theme/app/routes/sandbox.tsx
+++ b/theme/app/routes/sandbox.tsx
@@ -143,7 +143,7 @@ export default function ContentPage() {
       .filter((el) => el.ariaPressed === 'true')[0]
       .innerText.toLowerCase();
     const encoded = btoa(toBinary(document.getElementsByTagName('textarea')[0].value));
-    const params = new URLSearchParams(location.search);
+    const params = new URLSearchParams();
     params.set('tab', whichTab);
     params.set('myst', encoded);
     window.history.replaceState({}, '', `${location.pathname}?${params}`);


### PR DESCRIPTION
The PR to add the `url` param to the sandbox (#4) did not touch the copy logic. This logic presently preserves the query parameters, only overloading the shareable components. 

This PR changes that logic to start with a blank query, so that it _only_ contains the tab and MyST content information.