### PR TITLE
Update a few links from Executablebooks to Jupyter Book

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -82,7 +82,7 @@ Read about performance »
 :::
 
 :::{card}
-:link: https://compass.executablebooks.org/en/latest/strategy.html
+:link: https://mystmd.org/guide/guiding-principles
 
 **Composable Tools** 🧱
 ^^^
@@ -120,7 +120,7 @@ The MyST ecosystem is an open community supported by The Executable Book Project
 ::::{grid} 1 1 2 3
 
 :::{card}
-:link: https://executablebooks.org/en/latest/contribute/
+:link: https://mystmd.org/guide/contributing
 
 **Contribute** ⏭
 ^^^
@@ -136,7 +136,7 @@ Our gallery of Jupyter Books has contributions from across the community: from d
 :::
 
 :::{card}
-:link: https://compass.executablebooks.org/en/latest/strategy.html
+:link: https://compass.jupyterbook.org/
 
 **About Executable Books** ✨
 ^^^


### PR DESCRIPTION
updating a few links to jupyter-book in the home page. A few relevant points:

- We don't have a jupyter-book-wide strategy page. For now I'm linking to the guiding principles in mystmd.org/guide
- We don't have a gallery so I'm leaving the link to the EB gallery as-is until we get one.