### PR TITLE
FIX: updating gallery link to JB2

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -128,7 +128,7 @@ Read our Contributing Guide to learn about the conventions we follow, and see ou
 :::
 
 :::{card}
-:link: https://jupyterbook.org/latest/gallery/
+:link: https://jupyterbook.org/gallery/
 
 **Be inspired** 🚀
 ^^^

--- a/content/index.md
+++ b/content/index.md
@@ -128,7 +128,7 @@ Read our Contributing Guide to learn about the conventions we follow, and see ou
 :::
 
 :::{card}
-:link: https://executablebooks.org/en/latest/gallery/
+:link: https://jupyterbook.org/latest/gallery/
 
 **Be inspired** 🚀
 ^^^


### PR DESCRIPTION
As part of cleaning up a couple of old issues I opened about the docs. We now have a JB2 gallery, so we can link to it.

Resolves https://github.com/jupyter-book/mystmd/issues/2435