### PR TITLE
Fix bug on live mystmd.org site rendering grid-item directives

### DIFF
--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -27,7 +27,7 @@
         "classnames": "^2.5.1",
         "myst-common": "^1.9.5",
         "myst-config": "^1.9.5",
-        "myst-demo": "^1.1.4",
+        "myst-demo": "^1.2.2",
         "node-fetch": "^3.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -8883,9 +8883,9 @@
       }
     },
     "node_modules/@myst-theme/common": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@myst-theme/common/-/common-1.1.4.tgz",
-      "integrity": "sha512-wf8dONq6naDM5YB5w0tXjJLr99oRM1DKK4me91SGXRU3PJoXqspM0op/XAp/nJFf/ttIVuTTEpa+R8QxsG/qDg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@myst-theme/common/-/common-1.2.2.tgz",
+      "integrity": "sha512-64E7asxvMjoJF9eXEmO8JDBkcfmLQpsrPAOWUHmgJRNE1RF7za7Kh5e1ELyS2U/YfSDzapUq9trvBmrUamdQsA==",
       "license": "MIT",
       "dependencies": {
         "myst-common": "^1.8.1",
@@ -9023,13 +9023,14 @@
       }
     },
     "node_modules/@myst-theme/providers": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@myst-theme/providers/-/providers-1.1.4.tgz",
-      "integrity": "sha512-6vTJ2rQTbk9C6eo1DBF1FIziCwNt4wPq2V6vHhsTU4mEPOJRNtEo9lNgbiF9gjt38w+UuIJ9QTtml+iAh6y48g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@myst-theme/providers/-/providers-1.2.2.tgz",
+      "integrity": "sha512-IFicZyxnsGaQVPPAIDzNLsireQ1PJUPJGehC8NXXiK5z49/7WLqIHGZaR+37eQFlND6Mjohy6Sc5owF2B6G5CA==",
       "license": "MIT",
       "dependencies": {
-        "@myst-theme/common": "^1.1.4",
-        "@myst-theme/search": "^1.1.4"
+        "@myst-theme/common": "^1.2.2",
+        "@myst-theme/search": "^1.2.2",
+        "regexp.escape": "^2.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -9045,9 +9046,9 @@
       }
     },
     "node_modules/@myst-theme/search": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@myst-theme/search/-/search-1.1.4.tgz",
-      "integrity": "sha512-a2j/R+mBD9dE8hytd+iDFfr79RfRkW9IQD7i2NjRGEIxmZ/OqCiXk5ScE1M0AoPZrrL8KZ5/WL1eE/mRe9NqaA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@myst-theme/search/-/search-1.2.2.tgz",
+      "integrity": "sha512-qLPaidAwsiqk7bq8RHA5IvKV3g99X3Qn8ASwyDgleGmOXW7PyaOGBFdQxxlEvX1QpntP6xijCPFHA8oucd2iFw==",
       "license": "MIT"
     },
     "node_modules/@myst-theme/site": {
@@ -29592,9 +29593,9 @@
       }
     },
     "node_modules/myst-demo": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/myst-demo/-/myst-demo-1.1.4.tgz",
-      "integrity": "sha512-IaC88io5Wi04fFTMnBJWQ/dfR24Pj3JhMDR9q2+VNR9wkoHcrwI5inODDuhwcIfb9T33O8y0A86PvWEfMFXAbw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/myst-demo/-/myst-demo-1.2.2.tgz",
+      "integrity": "sha512-qCcZ0noY2WaQL6VUbzbyWlvFP+mK/eZI1Hr6BUiUC6Pirj4I+8HCbUcqnE3zeOiPW4apGCeJYl0f7IT6CrGMSw==",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
@@ -29615,7 +29616,7 @@
         "myst-to-docx": "^1.0.14",
         "myst-to-html": "^1.5.15",
         "myst-to-jats": "^1.0.34",
-        "myst-to-react": "^1.1.4",
+        "myst-to-react": "^1.2.2",
         "myst-to-tex": "^1.0.41",
         "myst-to-typst": "^0.0.33",
         "myst-transforms": "^1.3.37",
@@ -29759,9 +29760,9 @@
       }
     },
     "node_modules/myst-ext-grid": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/myst-ext-grid/-/myst-ext-grid-1.0.9.tgz",
-      "integrity": "sha512-GtlWFNDc9iZIasmu7gwjm41EtMa+Imr8IxWc4uLnve1HR6m9GmofNmcKoAViO2wz1ivv7ye7w1rzEf8qaatwqg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/myst-ext-grid/-/myst-ext-grid-1.1.0.tgz",
+      "integrity": "sha512-IupUCM1e5H08GYEPXKUMXOcLRfL/ciOllIFf7bPi9uOUuklzt71c/oStfFJJbVw1Sfv6Om4fJf9PmsupemBqzA==",
       "license": "MIT",
       "dependencies": {
         "myst-common": "^1.7.2"
@@ -30036,13 +30037,13 @@
       "license": "MIT"
     },
     "node_modules/myst-to-react": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/myst-to-react/-/myst-to-react-1.1.4.tgz",
-      "integrity": "sha512-RkujKhT4wDu99WLVjsgN7AfYt2QjRoiT4FVsNsL80P3Rf/QZ7+6A8xNXkdwC4zEkZdfMG/EulBuXxIn7a6WuoA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/myst-to-react/-/myst-to-react-1.2.2.tgz",
+      "integrity": "sha512-IuokiinABSOp/ZUHcBH7/WtFWpJxIazYr8cij4gKFAF6+A2EX/BHL7oLbtvjrotzTccdmKiboIIeWvZDg8d33w==",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
-        "@myst-theme/providers": "^1.1.4",
+        "@myst-theme/providers": "^1.2.2",
         "@radix-ui/react-hover-card": "^1.0.6",
         "@scienceicons/react": "^0.0.13",
         "buffer": "^6.0.3",
@@ -32826,6 +32827,26 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4"
+      }
+    },
+    "node_modules/regexp.escape": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexp.escape/-/regexp.escape-2.0.1.tgz",
+      "integrity": "sha512-JItRb4rmyTzmERBkAf6J87LjDPy/RscIwmaJQ3gsFlAzrmZbZU8LwBw5IydFZXW9hqpgbPlGbMhtpqtuAhMgtg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "for-each": "^0.3.3",
+        "safe-regex-test": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexp.prototype.flags": {

--- a/theme/package.json
+++ b/theme/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.5.1",
     "myst-common": "^1.9.5",
     "myst-config": "^1.9.5",
-    "myst-demo": "^1.1.4",
+    "myst-demo": "^1.2.2",
     "node-fetch": "^3.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
Live mystmd.org site has an issue rendering grid-item directive. https://mystmd.org/guide/dropdowns-cards-and-tabs

<img width="1400" height="900" alt="grid-bug-live-2" src="https://github.com/user-attachments/assets/6c9003f8-db8c-47ee-8ec3-1156a1a8c814" />

Updating the `myst-demo` version did the trick. Renders without issue now for me locally.