### PR TITLE
Fix primary sidebar

### DIFF
--- a/theme/app/components/Page.tsx
+++ b/theme/app/components/Page.tsx
@@ -8,7 +8,6 @@ import {
 import {
   SiteProvider,
   TabStateProvider,
-  UiStateProvider,
   useSiteManifest,
   useThemeTop,
 } from '@myst-theme/providers';
@@ -137,7 +136,7 @@ export function NavigationAndFooter({
   }
 
   return (
-    <UiStateProvider>
+    <>
       <SkipTo targets={[{ id: 'skip-to-article', title: 'Skip To Article' }]} />
       <SiteProvider config={mainSiteConfig ?? localSiteConfig}>
         <TopNav hide_toc={hide_toc} mobileNavOnly={mobileNavOnly} />
@@ -157,7 +156,7 @@ export function NavigationAndFooter({
         {children}
       </div>
       <Footer tight={tightFooter} />
-    </UiStateProvider>
+    </>
   );
 }
 

--- a/theme/app/root.tsx
+++ b/theme/app/root.tsx
@@ -12,7 +12,7 @@ import {
 import { Outlet, useLoaderData } from '@remix-run/react';
 import type { SiteLoader } from '@myst-theme/common';
 import type { NodeRenderers } from '@myst-theme/providers';
-import { BannerStateProvider, mergeRenderers } from '@myst-theme/providers';
+import { BannerStateProvider, UiStateProvider, mergeRenderers } from '@myst-theme/providers';
 import { JUPYTER_RENDERERS } from '@myst-theme/jupyter';
 import { ANY_RENDERERS } from '@myst-theme/anywidget';
 import { LANDING_PAGE_RENDERERS } from '@myst-theme/landing-pages';
@@ -56,11 +56,13 @@ export const loader: LoaderFunction = async ({ request }) => {
 function App() {
   const { theme, config } = useLoaderData<SiteLoader>();
   return (
-    <BannerStateProvider>
-      <Document theme={theme} config={config} renderers={RENDERERS}>
-        <Outlet />
-      </Document>
-    </BannerStateProvider>
+    <UiStateProvider>
+      <BannerStateProvider>
+        <Document theme={theme} config={config} renderers={RENDERERS}>
+          <Outlet />
+        </Document>
+      </BannerStateProvider>
+    </UiStateProvider>
   );
 }
 


### PR DESCRIPTION
This lifts the UIStateProvider above the document, which will let the primary sidebar use the screen width to calculate the sidebar height.
Currently it doesn't have access to the UI state, which is causing `useIsWide` to be false and thus not compute the correct sidebar height, leading to our bug.

This is basically the same thing we had to do in the myst-theme in the original PR here:

https://github.com/jupyter-book/myst-theme/pull/441/changes#diff-d122e33dbe055b7c93cc4a98b254fc8836142b26328fe5cd3c8d6c351b54cab4R124-R131

I tested this locally, and it fixed the sidebar overflow / scrolling problems.

---

- closes https://github.com/jupyter-book/mystmd/issues/2771
- closes https://github.com/jupyter-book/myst-theme/issues/837