### PR TITLE
Fix: Update links and language from Executable to Jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository holds the theme for https://mystmd.org as well as the content for the **landing/overview pages** of the website.
 
-The theme is a custom [Remix](https://remix.run) application that depends on [myst-theme](https://github.com/executablebooks/myst-theme) components. The web application brings together documentation from multiple different projects and provides a custom splash page, sandbox and search experience.
+The theme is a custom [Remix](https://remix.run) application that depends on [myst-theme](https://github.com/jupyter-book/myst-theme) components. The web application brings together documentation from multiple different projects and provides a custom splash page, sandbox and search experience.
 
 ## How to update the content at mystmd.org
 

--- a/content/ecosystem.md
+++ b/content/ecosystem.md
@@ -10,7 +10,7 @@ thumbnail: thumbnails/index.png
 The MyST ecosystem is evolving, with mature tools for Python and Sphinx, which support projects
 like [JupyterBook](https://jupyterbook.org).
 
-The [ExecutableBooks](https://executablebooks.org/) team is creating a [specification for MyST](https://mystmd.org/spec),
+The [Jupyter Book team](https://jupyterbook.org/compass) is creating a [specification for MyST](https://mystmd.org/spec),
 to allow parsers and renderers in many different tools and ecosystems, including in Javascript.
 The [mystmd project](https://mystmd.org/guide) is in beta and explores a command line interface for MyST in JavaScript
 and will change significantly and rapidly.
@@ -50,7 +50,7 @@ Go to Project »
 :::
 
 :::{card}
-:link: https://github.com/executablebooks/jupyterlab-myst
+:link: https://github.com/jupyter-book/jupyterlab-myst
 **JupyterLab**
 ^^^
 Write and render MyST markup directly in Jupyter Lab.

--- a/content/index.md
+++ b/content/index.md
@@ -115,7 +115,7 @@ MyST Spec »
 
 ## Open Community
 
-The MyST ecosystem is an open community supported by The Executable Book Project.
+The MyST ecosystem is an open community supported by The Jupyter Book Project.
 
 ::::{grid} 1 1 2 3
 
@@ -138,7 +138,7 @@ Our gallery of Jupyter Books has contributions from across the community: from d
 :::{card}
 :link: https://compass.jupyterbook.org/
 
-**About Executable Books** ✨
+**About Jupyter Book** ✨
 ^^^
 Learn more about our project’s goals and strategy, list of core team members, and meeting notes and team calendar.
 :::

--- a/theme/LICENSE
+++ b/theme/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 Executable Books Project
+Copyright (c) 2024 Jupyter Book Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/theme/app/components/Footer.tsx
+++ b/theme/app/components/Footer.tsx
@@ -19,7 +19,7 @@ function SocialIcons() {
         <TwitterIcon className="w-5 h-5" />
       </a>
       <a
-        href="https://fosstodon.org/@myst_tools"
+        href="https://fosstodon.org/@mystmarkdown"
         target="_blank"
         className="p-1"
         rel="me noreferrer"
@@ -28,7 +28,7 @@ function SocialIcons() {
         <MastodonIcon className="w-5 h-5" />
       </a>
       <a
-        href="https://github.com/executablebooks"
+        href="https://github.com/jupyter-book/mystmd"
         target="_blank"
         className="p-1"
         rel="noreferrer"
@@ -83,7 +83,7 @@ export function JupyterFooter() {
             Compass
           </a>
           <a
-            href="https://executablebooks.org/en/latest/blog"
+            href="https://jupyterbook.org/blog"
             target="_blank"
             rel="noreferrer"
             className="text-sm"

--- a/theme/app/components/TopNav.tsx
+++ b/theme/app/components/TopNav.tsx
@@ -187,7 +187,7 @@ function ThemeTag() {
         <MastodonIcon className="w-5 h-5" />
       </a>
       <a
-        href="https://github.com/jupyter-book"
+        href="https://github.com/jupyter-book/mystmd"
         target="_blank"
         className="p-1.5 hover:opacity-80"
         rel="noreferrer"


### PR DESCRIPTION
Written in collaboration with @stefanv

* Updates links in TopNav and Footer to point to expected destinations
* Changes a few instances of "Executable Books" to "Jupyter Book" in site copy